### PR TITLE
Fix scopes in google oauth

### DIFF
--- a/taskw_gcal_sync/GCalSide.py
+++ b/taskw_gcal_sync/GCalSide.py
@@ -23,7 +23,7 @@ class GCalSide(GenericSide):
     OAuth2 user authentication workflow.
     """
 
-    SCOPES = "https://www.googleapis.com/auth/calendar"
+    SCOPES = ["https://www.googleapis.com/auth/calendar"]
     _datetime_format = "%Y-%m-%dT%H:%M:%S.%fZ"
     _date_format = "%Y-%m-%d"
 


### PR DESCRIPTION
When the token for google oauth has expired and need refresh, I encountered an Exception:
```
.
.
.
  File "/home/soraxas/.local/lib/python3.6/site-packages/google/oauth2/_client.py", line 244, in refresh_grant
    response_data = _token_endpoint_request(request, token_uri, body)
  File "/home/soraxas/.local/lib/python3.6/site-packages/google/oauth2/_client.py", line 120, in _token_endpoint_request
    _handle_error_response(response_body)
  File "/home/soraxas/.local/lib/python3.6/site-packages/google/oauth2/_client.py", line 60, in _handle_error_response
    raise exceptions.RefreshError(error_details, response_body)

google.auth.exceptions.RefreshError: ('invalid_scope: Some requested scopes were invalid. {invalid=[a, c, d, e, g, h, i, l, m, ., n, /, o, p, r, s, t, u, w, :]}', '{\n  "error": "invalid_scope",\n  "error_description": "Some requested scopes were invalid. {invalid\\u003d[a, c, d, e, g, h, i, l, m, ., n, /, o, p, r, s, t, u, w, :]}",\n  "error_uri": "http://code.google.com/apis/accounts/docs/OAuth2.html"\n}')
```
which is because the argument for scopes should be a list of scope (i.e. list of strings) instead of a single string (ref. [Example in Google Calendar API](https://developers.google.com/calendar/quickstart/python) Step 3). In that given example, it uses `SCOPES = ['https://www.googleapis.com/auth/calendar.readonly']`.